### PR TITLE
Implement current conference for each user

### DIFF
--- a/src/migrations/20170825154938_authorization.js
+++ b/src/migrations/20170825154938_authorization.js
@@ -3,6 +3,10 @@ exports.up = function(knex, Promise) {
   return Promise.all([
     knex.schema.createTable('users', table => {
       table.increments('id').primary();
+      table
+        .integer('current_conference_id')
+        .notNullable()
+        .default(0);
       table.string('firstname').notNullable();
       table.string('lastname').notNullable();
       table.string('password').notNullable();

--- a/src/models/authorization/user.js
+++ b/src/models/authorization/user.js
@@ -26,6 +26,7 @@ export default class User extends unique(Model) {
     required: ['firstname', 'lastname', 'email', 'password', 'gender'],
     properties: {
       id: { type: 'number' },
+      current_conference_id: { type: 'number' },
       firstname: { type: 'string', maxLength: '100' },
       lastname: { type: 'string', maxLength: '255' },
       email: {

--- a/src/schema/resolvers/schedule/personalScheduleResolves.js
+++ b/src/schema/resolvers/schedule/personalScheduleResolves.js
@@ -27,14 +27,15 @@ export default {
         throw new ValidationError('unauthorized');
       }
       try {
-        const personalSchedules = await PersonalSchedule.query().where(
-          'user_id',
-          user.id,
-        );
+        if (user.current_conference_id === 0) {
+          throw new ValidationError('no-current-conference');
+        }
+        const personalSchedules = await PersonalSchedule.query()
+          .where('user_id', user.id)
+          .andWhere('conference_id', user.current_conference_id);
         return personalSchedules;
       } catch (e) {
         // eslint-disable-next-line no-console
-        console.error(e);
         throw new ValidationError(e);
       }
     },
@@ -47,12 +48,16 @@ export default {
         throw new ValidationError('unauthorized');
       }
       try {
+        if (user.current_conference_id === 0) {
+          throw new ValidationError('no-current-conference');
+        }
         const personalSchedule = await PersonalSchedule.query()
           .where('user_id', user.id)
           .andWhere('id', id)
+          .andWhere('conference_id', user.current_conference_id)
           .first();
         if (!personalSchedule) {
-          throw new ValidationError('PersonalSchedule-not-found');
+          throw new ValidationError('personal-chedule-not-found');
         }
         return personalSchedule;
       } catch (e) {

--- a/src/schema/resolvers/schedule/scheduleResolvers.js
+++ b/src/schema/resolvers/schedule/scheduleResolvers.js
@@ -28,14 +28,21 @@ export default {
     getAllSchedules: async (
       root,
       data,
-      { models: { Schedule }, ValidationError },
+      { models: { Schedule }, ValidationError, user },
     ) => {
+      if (!user) {
+        throw new ValidationError('unauthorized');
+      }
       try {
-        const schedules = await Schedule.query().orderBy('start', 'desc');
+        if (user.current_conference_id === 0) {
+          throw new ValidationError('no-current-conference');
+        }
+        const schedules = await Schedule.query()
+          .where('conference_id', user.current_conference_id)
+          .orderBy('start', 'desc');
         return schedules;
       } catch (e) {
         // eslint-disable-next-line no-console
-        console.error(e);
         throw new ValidationError(e);
       }
     },

--- a/src/schema/types/authorization/userTypes.js
+++ b/src/schema/types/authorization/userTypes.js
@@ -60,6 +60,9 @@ type User {
   # permissions of users
   permissions: [Permission!]!
 
+  # The current conference session of each user
+  currentConference: Conference
+
   # personal feedback
   activityFeedback: [ActivityFeedback!]
 
@@ -109,6 +112,8 @@ extend type Query {
     userId: ID!): User!
   # Get information about current logged in user, need Authorization and RefreshToken headers
   me: User!
+  # Get current conference session of user
+  getCurrentConference: Conference!
 }
 
 extend type Mutation {
@@ -179,6 +184,11 @@ extend type Mutation {
 
   # delete user with id
   deleteUser(id: ID!): User!
+
+  # Switch current conference session of user
+  switchCurrentConference(
+    conference_id: ID!
+  ): Conference!
 }
 
 type LoginResponse {

--- a/src/schema/types/schedule/scheduleTypes.js
+++ b/src/schema/types/schedule/scheduleTypes.js
@@ -15,7 +15,7 @@ type Schedule {
   # activity status
   activity_status: Status!
 
-  # conference 
+  # conference
   conference: Conference!
 
   # room of activity in schedule


### PR DESCRIPTION
I have added a 1-1 relationship for user current conference (`current_conference_id`) & schemas for this PR.

- Query
```
getCurrentConference: Conference!
```

- Mutation
```
switchCurrentConference (conference_id: ID!): Conference!
```

I will apply this API to the mobile soon.
@lednhatkhanh please help me review to find out any problem with this PR.
After that, @tranvanthuc will apply this API to the admin site.
